### PR TITLE
allow to specify includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This implements what people were asking for in some mkdocs bugs, such as
            - "*.gz"
          regex:
            - '.*\.(tmp|bin|tar)$'
+         include-glob:
+           - include/this/path/*
+           - "*.png"
+           - "*.md"
+           - "assets/**" # the material theme requires this folder
+         include-regex:
+           - '.*\.(js|css)$'
    ```
 
 You can provide zero or more patterns of each type.  (If you don't provide
@@ -41,3 +48,8 @@ quoted.
 When writing regexes, it's best to use single quotes rather than double
 quotes, so that your regex backslash escapes are preserved correctly without
 having to be doubled up.
+
+## Exclude and Include
+
+It is possible to exclude and include. For example you could exclude `*` but include `*.md`.
+Include has higher priority over exclude.

--- a/mkdocs_exclude/plugin.py
+++ b/mkdocs_exclude/plugin.py
@@ -6,47 +6,83 @@ import mkdocs
 import mkdocs.plugins
 import mkdocs.structure.files
 
+class ExcludeDecider:
+    def __init__(self, globs, regexes, include_globs, include_regexes):
+        self.globs = globs
+        self.regexes = regexes
+        self.include_globs = include_globs
+        self.include_regexes = include_regexes
+
+    def is_include(self, file):
+        if not self._is_include(file):
+            if file.endswith(".md"):
+                print("NO", self.include_globs)
+            return False
+        # Windows reports filenames as eg.  a\\b\\c instead of a/b/c.
+        # To make the same globs/regexes match filenames on Windows and
+        # other OSes, let's try matching against converted filenames.
+        # On the other hand, Unix actually allows filenames to contain
+        # literal \\ characters (although it is rare), so we won't
+        # always convert them.  We only convert if os.sep reports
+        # something unusual.  Conversely, some future mkdocs might
+        # report Windows filenames using / separators regardless of
+        # os.sep, so we *always* test with / above.
+        if os.sep != '/':
+            filefix = file.replace(os.sep, '/')
+            if not self._is_include(filefix):
+                return False
+        return True
+
+    def _is_include(self, file):
+        for g in self.include_globs:
+            if fnmatch.fnmatchcase(file, g):
+                return True
+        for r in self.include_regexes:
+            if re.match(r, file):
+                return True
+        for g in self.globs:
+            if fnmatch.fnmatchcase(file, g):
+                return False
+        for r in self.regexes:
+            if re.match(r, file):
+                return False
+        return True
+
+def get_list_from_config(name, config):
+    """ Gets a list item from config. If it doesn't exist, gets empty list.
+    If it is not a list, wrap it in a list """
+    result = config[name] or []
+    if not isinstance(result, list):
+        result = [result]
+    return result
+
 class Exclude(mkdocs.plugins.BasePlugin):
     """A mkdocs plugin that removes all matching files from the input list."""
 
     config_scheme = (
         ('glob', mkdocs.config.config_options.Type((str, list), default=None)),
         ('regex', mkdocs.config.config_options.Type((str, list), default=None)),
+        ('include-glob', mkdocs.config.config_options.Type((str, list), default=None)),
+        ('include-regex', mkdocs.config.config_options.Type((str, list), default=None)),
     )
 
     def on_files(self, files, config):
-        globs = self.config['glob'] or []
-        if not isinstance(globs, list):
-            globs = [globs]
-        regexes = self.config['regex'] or []
-        if not isinstance(regexes, list):
-            regexes = [regexes]
+        for k in self.config:
+            for scheme in self.config_scheme:
+                if scheme[0] == k:
+                    break
+            else:
+                raise Exception("Configuration '%s' not found for exclude-plugin" % k)
+
+        globs = get_list_from_config('glob', self.config)
+        regexes = get_list_from_config('regex', self.config)
+        include_globs = get_list_from_config('include-glob', self.config)
+        include_regexes = get_list_from_config('include-regex', self.config)
+        exclude_decider = ExcludeDecider(globs, regexes, include_globs, include_regexes)
         out = []
-        def include(name):
-            for g in globs:
-                if fnmatch.fnmatchcase(name, g):
-                    return False
-            for r in regexes:
-                if re.match(r, name):
-                    return False
-            return True
         for i in files:
             name = i.src_path
-            if not include(name):
-                continue
-
-            # Windows reports filenames as eg.  a\\b\\c instead of a/b/c.
-            # To make the same globs/regexes match filenames on Windows and
-            # other OSes, let's try matching against converted filenames.
-            # On the other hand, Unix actually allows filenames to contain
-            # literal \\ characters (although it is rare), so we won't
-            # always convert them.  We only convert if os.sep reports
-            # something unusual.  Conversely, some future mkdocs might
-            # report Windows filenames using / separators regardless of
-            # os.sep, so we *always* test with / above.
-            if os.sep != '/':
-                namefix = name.replace(os.sep, '/')
-                if not include(namefix):
-                    continue
-            out.append(i)
+            if exclude_decider.is_include(name):
+                print("include:",name)
+                out.append(i)
         return mkdocs.structure.files.Files(out)

--- a/mkdocs_exclude/plugin.py
+++ b/mkdocs_exclude/plugin.py
@@ -15,8 +15,6 @@ class ExcludeDecider:
 
     def is_include(self, file):
         if not self._is_include(file):
-            if file.endswith(".md"):
-                print("NO", self.include_globs)
             return False
         # Windows reports filenames as eg.  a\\b\\c instead of a/b/c.
         # To make the same globs/regexes match filenames on Windows and

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def read(name):
 
 setuptools.setup(
     name='mkdocs-exclude',
-    version='1.0.2',
+    version='1.0.3',
     packages=['mkdocs_exclude'],
     url='https://github.com/apenwarr/mkdocs-exclude',
     license='Apache',


### PR DESCRIPTION
As I wrote in #3, not everything can be expressed with negative lookahead/lookback in regexes. Also having the include feature, would make it way easier.

I hope its fine, that I also did some restructuring to avoid having such a big inner method.

I have it running with following settings:
```yml
  - exclude:
      include-glob:
        - "*.md"
        - "docs/*"
        - "assets/*"
      glob:
        - "*"
```

edit: removed `**` since it has no effect