### PR TITLE
Add `gitignore` config boolean to exclude files ignored by `git`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This implements what people were asking for in some mkdocs bugs, such as
    ```yaml
    plugins:
      - exclude:
+         gitignore: true
          glob:
            - exclude/this/path/*
            - "*.tmp"
@@ -41,3 +42,18 @@ quoted.
 When writing regexes, it's best to use single quotes rather than double
 quotes, so that your regex backslash escapes are preserved correctly without
 having to be doubled up.
+
+Setting `gitignore` to `true` will ignore files if `git` ignores them.<sup>1</sup> (This
+defaults to `false` if omitted.)
+
+---
+
+<sup>1</sup> Some environments like [`tox`](https://tox.readthedocs.io/) do not pass on
+the `HOME` environment variable by default. `git` uses `HOME` to expand configurations
+like `excludesfile = ~/.gitignore`. If you rely on `git` configurations other than what
+lives in your repository, this can lead to disparities between what you observe when
+running `git` in your shell versus what gets ignored by this plugin. If you experience
+this and are unable to move the requisite configuration into your repository’s
+`.gitignore` file(s), consider exposing the `HOME` environment variable to your build
+environment, or modifying `.git/config` or `.git/info/exclude` in your local repository
+copy.


### PR DESCRIPTION
Inspired by [`pytest_gitignore.py` from tgs/pytest-gitignore](https://github.com/tgs/pytest-gitignore/blob/7dc7087f16dbc467435e08f7faeac64d7ee0f0a1/pytest_gitignore.py#L18-L35).