### PR TITLE
Use from import to allow use with mkdocs 1.2.3

### DIFF
--- a/mkdocs_exclude/plugin.py
+++ b/mkdocs_exclude/plugin.py
@@ -4,13 +4,14 @@ import os
 import mkdocs
 import mkdocs.plugins
 import mkdocs.structure.files
+from mkdocs.config.config_options import Type
 
 class Exclude(mkdocs.plugins.BasePlugin):
     """A mkdocs plugin that removes all matching files from the input list."""
 
     config_scheme = (
-        ('glob', mkdocs.config.config_options.Type((str, list), default=None)),
-        ('regex', mkdocs.config.config_options.Type((str, list), default=None)),
+        ('glob', Type((str, list), default=None)),
+        ('regex', Type((str, list), default=None)),
     )
 
     def on_files(self, files, config):

--- a/mkdocs_exclude/plugin.py
+++ b/mkdocs_exclude/plugin.py
@@ -1,7 +1,6 @@
 import fnmatch
 import re
 import os
-import sys
 import mkdocs
 import mkdocs.plugins
 import mkdocs.structure.files


### PR DESCRIPTION
This PR addresses a bug where `mkdocs_exclude` cannot be imported with mkdocs
1.2.3 as some submodules of `mkdocs` have been removed from their parents.
